### PR TITLE
Flush gpg-agent on setting pinentry-program

### DIFF
--- a/Source/GPGTask.m
+++ b/Source/GPGTask.m
@@ -282,6 +282,7 @@ static NSString *GPG_STATUS_PREFIX = @"[GNUPG:] ";
         if ([possibleBins count] > 0) {
             inconfPath = [possibleBins objectAtIndex:0];
             [options setValue:inconfPath forKey:kPinentry_program inDomain:GPGDomain_gpgAgentConf];
+            [options gpgAgentFlush];
         }
     }
 


### PR DESCRIPTION
Testing reveals that a running gpg-agent needs a HUP in order to recognize a new pinentry-program.
