### PR TITLE
fcntl F_SETNOSIGPIPE so gpg2 early termination doesn't cause exit

### DIFF
--- a/Source/GPGTask.h
+++ b/Source/GPGTask.h
@@ -72,6 +72,8 @@
 	
 	dispatch_group_t collectorGroup;
 	dispatch_queue_t queue;
+	// safe to write without locking because only one thread writes
+	NSException *writeException;
 	NSInteger inDataLength;
 	NSInteger progressedLength;
 	NSMutableDictionary *progressedLengths;


### PR DESCRIPTION
Hi. This contribution arises from earlier frustration in testing GPGServices
where my test case kept dying from SIGPIPE. 

The test case was invalid data (on purpose), and gpg2 was terminating 
early, but the signal was also taking down GPGServices. I tried masking it 
out with sigprocmask, pthread_sigmask, etc., but to no avail.

On 10.7+ only, there is now a fcntl operation called F_SETNOSIGPIPE
which does the trick nicely. Since we're on the 10.6 SDK, I conditionally
define the constant. 

It will work on Lion and I believe do nothing on earlier versions—they'll still 
terminate unexpectedly). On Lion, it'll be handled as a GPGTask exception.
