### PR TITLE
Add GPGStream-based methods to GPGController.

### DIFF
--- a/Libmacgpg.xcodeproj/project.pbxproj
+++ b/Libmacgpg.xcodeproj/project.pbxproj
@@ -70,6 +70,12 @@
 		45156A2D14FB506E00129FE7 /* GPGArraySettingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 45156A2C14FB506E00129FE7 /* GPGArraySettingTest.m */; };
 		451932F514F8061100D1F727 /* GPGStdSetting.h in Headers */ = {isa = PBXBuildFile; fileRef = 451932F314F8061100D1F727 /* GPGStdSetting.h */; };
 		451932F614F8061100D1F727 /* GPGStdSetting.m in Sources */ = {isa = PBXBuildFile; fileRef = 451932F414F8061100D1F727 /* GPGStdSetting.m */; };
+		451D8829156A7AD900A0B890 /* GPGStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 451D8827156A7AD900A0B890 /* GPGStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		451D882A156A7AD900A0B890 /* GPGStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 451D8828156A7AD900A0B890 /* GPGStream.m */; };
+		451D882D156A7CA300A0B890 /* GPGMemoryStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 451D882B156A7CA300A0B890 /* GPGMemoryStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		451D882E156A7CA300A0B890 /* GPGMemoryStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 451D882C156A7CA300A0B890 /* GPGMemoryStream.m */; };
+		451D8831156A7E4900A0B890 /* GPGFileStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 451D882F156A7E4900A0B890 /* GPGFileStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		451D8832156A7E4900A0B890 /* GPGFileStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 451D8830156A7E4900A0B890 /* GPGFileStream.m */; };
 		4547646614FBC8A900A37306 /* GPGStdSettingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4547646514FBC8A900A37306 /* GPGStdSettingTest.m */; };
 		455B17BA15143D9A00FAD47D /* GPGOptionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 455B17B915143D9A00FAD47D /* GPGOptionsTest.m */; };
 		4570876614FAA7C90030AAE6 /* GPGConfReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 4570876414FAA7C90030AAE6 /* GPGConfReader.h */; };
@@ -181,6 +187,12 @@
 		45156A2C14FB506E00129FE7 /* GPGArraySettingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GPGArraySettingTest.m; sourceTree = "<group>"; };
 		451932F314F8061100D1F727 /* GPGStdSetting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = GPGStdSetting.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		451932F414F8061100D1F727 /* GPGStdSetting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = GPGStdSetting.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		451D8827156A7AD900A0B890 /* GPGStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GPGStream.h; sourceTree = "<group>"; };
+		451D8828156A7AD900A0B890 /* GPGStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GPGStream.m; sourceTree = "<group>"; };
+		451D882B156A7CA300A0B890 /* GPGMemoryStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GPGMemoryStream.h; sourceTree = "<group>"; };
+		451D882C156A7CA300A0B890 /* GPGMemoryStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GPGMemoryStream.m; sourceTree = "<group>"; };
+		451D882F156A7E4900A0B890 /* GPGFileStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GPGFileStream.h; sourceTree = "<group>"; };
+		451D8830156A7E4900A0B890 /* GPGFileStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GPGFileStream.m; sourceTree = "<group>"; };
 		4547646514FBC8A900A37306 /* GPGStdSettingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GPGStdSettingTest.m; sourceTree = "<group>"; };
 		455B17B915143D9A00FAD47D /* GPGOptionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GPGOptionsTest.m; sourceTree = "<group>"; };
 		4570876414FAA7C90030AAE6 /* GPGConfReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = GPGConfReader.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
@@ -295,6 +307,12 @@
 				3048830E1462B22000F2E5F4 /* GPGWatcher.m */,
 				304883091462B11700F2E5F4 /* DirectoryWatcher.h */,
 				3048830A1462B11700F2E5F4 /* DirectoryWatcher.m */,
+				451D8827156A7AD900A0B890 /* GPGStream.h */,
+				451D8828156A7AD900A0B890 /* GPGStream.m */,
+				451D882B156A7CA300A0B890 /* GPGMemoryStream.h */,
+				451D882C156A7CA300A0B890 /* GPGMemoryStream.m */,
+				451D882F156A7E4900A0B890 /* GPGFileStream.h */,
+				451D8830156A7E4900A0B890 /* GPGFileStream.m */,
 			);
 			name = Classes;
 			path = Source;
@@ -443,6 +461,9 @@
 				45156A1C14FB1B1200129FE7 /* GPGLinesSetting.h in Headers */,
 				45156A2014FB1D7D00129FE7 /* GPGDictSetting.h in Headers */,
 				45156A2A14FB3EF700129FE7 /* GPGArraySetting.h in Headers */,
+				451D8829156A7AD900A0B890 /* GPGStream.h in Headers */,
+				451D882D156A7CA300A0B890 /* GPGMemoryStream.h in Headers */,
+				451D8831156A7E4900A0B890 /* GPGFileStream.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -624,6 +645,9 @@
 				45156A1D14FB1B1200129FE7 /* GPGLinesSetting.m in Sources */,
 				45156A2114FB1D7D00129FE7 /* GPGDictSetting.m in Sources */,
 				45156A2B14FB3EF700129FE7 /* GPGArraySetting.m in Sources */,
+				451D882A156A7AD900A0B890 /* GPGStream.m in Sources */,
+				451D882E156A7CA300A0B890 /* GPGMemoryStream.m in Sources */,
+				451D8832156A7E4900A0B890 /* GPGFileStream.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/GPGController.h
+++ b/Source/GPGController.h
@@ -24,6 +24,7 @@
 
 @class GPGSignature;
 @class GPGController;
+@class GPGStream;
 
 @protocol GPGControllerDelegate
 @optional
@@ -171,10 +172,17 @@
 - (void)key:(NSObject <KeyFingerprint> *)key setDisabled:(BOOL)disabled;
 - (void)key:(NSObject <KeyFingerprint> *)key setOwnerTrsut:(GPGValidity)trust;
 
+- (void)processTo:(GPGStream *)output data:(GPGStream *)input withEncryptSignMode:(GPGEncryptSignMode)encryptSignMode 
+			 recipients:(NSObject <EnumerationList> *)recipients hiddenRecipients:(NSObject <EnumerationList> *)hiddenRecipients;
 - (NSData *)processData:(NSData *)data withEncryptSignMode:(GPGEncryptSignMode)encryptSignMode 
 			 recipients:(NSObject <EnumerationList> *)recipients hiddenRecipients:(NSObject <EnumerationList> *)hiddenRecipients;
+
+- (void)decryptTo:(GPGStream *)output data:(GPGStream *)input;
 - (NSData *)decryptData:(NSData *)data;
+
+- (NSArray *)verifySignatureOf:(GPGStream *)signatureInput originalData:(GPGStream *)originalInput;
 - (NSArray *)verifySignature:(NSData *)signatureData originalData:(NSData *)originalData;
+
 - (NSArray *)verifySignedData:(NSData *)signedData;
 - (NSSet *)keysInExportedData:(NSData *)data;
 

--- a/Source/GPGFileStream.h
+++ b/Source/GPGFileStream.h
@@ -1,0 +1,32 @@
+//
+//  GPGFileStream.h
+//  Libmacgpg
+//
+//  Created by Chris Fraire on 5/21/12.
+//  Copyright (c) 2012 Chris Fraire. All rights reserved.
+//
+
+#import "GPGStream.h"
+
+// you can call the read methods of GPGStream on a writeable 
+// GPGFileStream, at which point it will convert to a readable
+// stream (from offset 0) and no longer be writeable
+@interface GPGFileStream : GPGStream {
+    NSString *_filepath;
+    // for writing
+    NSFileHandle *_fh;
+    // for reading
+    NSFileHandle *_readfh;
+    // for readable files
+    unsigned long long _flength;
+}
+
+// returns nil if creating file for writing failed
++ (id)fileStreamForWritingAtPath:(NSString *)path;
+// returns nil if opening file for reading failed
++ (id)fileStreamForReadingAtPath:(NSString *)path;
+
+- (id)initForWritingAtPath:(NSString *)path error:(NSError **)error;
+- (id)initForReadingAtPath:(NSString *)path error:(NSError **)error;
+
+@end

--- a/Source/GPGFileStream.m
+++ b/Source/GPGFileStream.m
@@ -1,0 +1,176 @@
+//
+//  GPGFileStream.m
+//  Libmacgpg
+//
+//  Created by Chris Fraire on 5/21/12.
+//  Copyright (c) 2012 Chris Fraire. All rights reserved.
+//
+
+#import "GPGFileStream.h"
+
+@interface GPGFileStream ()
+// might be called (internally) for a writeable stream after writing
+- (void)openForReading;
+@end
+
+@implementation GPGFileStream
+
+- (void)dealloc
+{
+    [_filepath release];
+    [_fh release];
+    [_readfh release];
+    [super dealloc];
+}
+
+- (id)init {
+    return [self initForWritingAtPath:nil error:nil];
+}
+
++ (id)fileStreamForWritingAtPath:(NSString *)path {
+    NSError *error = nil;
+    id newObject = [[[self alloc] initForWritingAtPath:path error:&error] autorelease];
+    if (error)
+        return nil;
+    return newObject;
+}
+
++ (id)fileStreamForReadingAtPath:(NSString *)path {
+    NSError *error = nil;
+    id newObject = [[[self alloc] initForReadingAtPath:path error:&error] autorelease];
+    if (error)
+        return nil;
+    return newObject;
+}
+
+- (id)initForWritingAtPath:(NSString *)path error:(NSError **)error
+{
+    if (self = [super init]) {
+        _filepath = [path retain];
+
+        if (path) {
+            _fh = [[NSFileHandle fileHandleForWritingAtPath:path] retain];
+
+            if (!_fh) {
+                if (error)
+                    *error = [NSError errorWithDomain:@"libc" code:0 userInfo:nil];
+            }
+        }
+        else {
+            _fh = [[NSFileHandle fileHandleWithNullDevice] retain];
+        }
+    }
+
+    return self;
+}
+
+- (id)initForReadingAtPath:(NSString *)path error:(NSError **)error
+{
+    if (self = [super init]) {
+        _filepath = [path retain];
+
+        if (path) {
+            [self openForReading];
+            if (!_readfh) {
+                if (error)
+                    *error = [NSError errorWithDomain:@"libc" code:0 userInfo:nil];
+            }
+        }
+        else {
+            _readfh = [[NSFileHandle fileHandleWithNullDevice] retain];
+        }
+    }
+    
+    return self;
+}
+
+- (void)writeData:(NSData *)data 
+{
+    if (_readfh)
+        @throw [NSException exceptionWithName:@"InvalidOperationException" reason:@"stream is readable" userInfo:nil];
+    [_fh writeData:data];
+}
+
+- (NSData *)readDataToEndOfStream
+{
+    if (!_readfh)
+        [self openForReading];
+    return [_readfh readDataToEndOfFile];
+}
+
+- (NSData *)readDataOfLength:(NSUInteger)length {
+    if (!_readfh)
+        [self openForReading];
+    return [_readfh readDataOfLength:length];
+}
+
+- (NSData *)readAllData {
+    if (!_readfh) 
+        [self openForReading];
+    [_readfh seekToFileOffset:0];
+    return [_readfh readDataToEndOfFile];
+}
+
+- (char)peekByte {
+    if (!_readfh)
+        [self openForReading];
+
+    unsigned long long currentPos = [_readfh offsetInFile];
+    NSData *peek = [_readfh readDataOfLength:1];
+    [_readfh seekToFileOffset:currentPos];
+
+    if (peek && [peek length])
+        return *(char *)[peek bytes];
+    return 0;
+}
+
+- (void)close 
+{
+    [_fh closeFile];
+    if (_readfh) {
+        [_readfh closeFile];
+        // release and nil so it could be re-opened if necessary
+        [_readfh release];
+        _readfh = nil;
+    }
+}
+
+- (void)flush {
+    [_fh synchronizeFile];
+}
+
+- (void)seekToBeginning 
+{
+    if (_fh) {
+        [_fh truncateFileAtOffset:0];
+    }
+    if (_readfh) {
+        [_readfh seekToFileOffset:0];
+    }
+}
+
+- (unsigned long long)length
+{
+    if (_readfh)
+        return _flength;
+    return [_fh offsetInFile];
+}
+
+#pragma mark - private
+
+- (void)openForReading 
+{
+    if (_fh) {
+        [_fh closeFile];
+        [_fh release];
+        _fh = nil;
+    }
+    if (!_readfh)
+    {
+        _readfh = [[NSFileHandle fileHandleForReadingAtPath:_filepath] retain];
+        _flength = [_readfh seekToEndOfFile];
+        [_readfh seekToFileOffset:0];
+    }
+}
+
+@end

--- a/Source/GPGMemoryStream.h
+++ b/Source/GPGMemoryStream.h
@@ -1,0 +1,27 @@
+//
+//  GPGMemoryStream.h
+//  Libmacgpg
+//
+//  Created by Chris Fraire on 5/21/12.
+//  Copyright (c) 2012 Chris Fraire. All rights reserved.
+//
+
+#import "GPGStream.h"
+
+// you can call the read methods of GPGStream on a writeable 
+// GPGFileStream, at which point it will convert to a readable
+// stream (from offset 0) and no longer be writeable
+@interface GPGMemoryStream : GPGStream {
+    NSMutableData *_data;
+    NSData *_readableData;
+    unsigned long long _readPos;
+}
+
+// return a new, autoreleased memory stream
++ (id)memoryStream;
+// return a new, autoreleased memory stream atop the specified data 
++ (id)memoryStreamForReading:(NSData *)data;
+
+- (id)initForReading:(NSData *)data;
+
+@end

--- a/Source/GPGMemoryStream.m
+++ b/Source/GPGMemoryStream.m
@@ -1,0 +1,142 @@
+//
+//  GPGMemoryStream.m
+//  Libmacgpg
+//
+//  Created by Chris Fraire on 5/21/12.
+//  Copyright (c) 2012 Chris Fraire. All rights reserved.
+//
+
+#import "GPGMemoryStream.h"
+
+@interface GPGMemoryStream ()
+// might be called (internally) for a writeable stream after writing
+- (void)openForReading;
+@end
+
+@implementation GPGMemoryStream
+
+- (void)dealloc 
+{
+    [_data release];
+    [_readableData release];
+    [super dealloc];
+}
+
+- (id)init 
+{
+    if (self = [super init]) {
+        _data = [[NSMutableData data] retain];
+        // _readableData stays nil
+    }
+    return self;
+}
+
+- (id)initForReading:(NSData *)data
+{
+    if (self = [super init]) {
+        // _data stays nil
+        _readableData = [data retain];
+    }
+    return self;
+}
+
++ (id)memoryStream 
+{
+    return [[[self alloc] init] autorelease];
+}
+
++ (id)memoryStreamForReading:(NSData *)data
+{
+    return [[[self alloc] initForReading:data] autorelease];
+}
+
+- (void)writeData:(NSData *)data
+{
+    if (!_data)
+        @throw [NSException exceptionWithName:@"InvalidOperationException" reason:@"stream is readable" userInfo:nil];
+    [_data appendData:data];
+}
+
+- (NSData *)readDataToEndOfStream
+{
+    if (!_readableData) 
+        [self openForReading];
+
+    unsigned long long rlength = [_readableData length];
+    if (_readPos >= rlength)
+        return [NSData data];
+
+    NSData *result = [_readableData subdataWithRange:NSMakeRange(_readPos, rlength - _readPos)];
+    _readPos = rlength;
+    return result;
+}
+
+- (NSData *)readDataOfLength:(NSUInteger)length
+{
+    if (!_readableData) 
+        [self openForReading];
+        
+    unsigned long long rlength = [_readableData length];
+    if (_readPos >= rlength)
+        return [NSData data];
+
+    NSUInteger nextLength = MIN(length, rlength - _readPos);
+    NSData *result = [_readableData subdataWithRange:NSMakeRange(_readPos, nextLength)];
+    _readPos += nextLength;
+    return result;
+}
+
+- (NSData *)readAllData 
+{
+    if (!_readableData)
+        [self openForReading];
+
+    return [[_readableData retain] autorelease];
+}
+
+- (char)peekByte 
+{
+    if (!_readableData)
+        [self openForReading];
+
+    unsigned long long rlength = [_readableData length];
+    if (_readPos >= rlength)
+        return 0;
+
+    char buf[1] = {0};
+    [_readableData getBytes:&buf range:NSMakeRange(_readPos, 1)];
+    return buf[0];
+}
+
+/// flush does nothing special
+
+/// close does nothing special
+
+- (void)seekToBeginning
+{
+    if (_data)
+        [_data setLength:0];
+    if (_readableData) 
+        _readPos = 0;
+}
+
+- (unsigned long long)length
+{
+    if (_readableData)
+        return [_readableData length];
+    return [_data length];
+}
+
+#pragma mark - private
+
+- (void)openForReading 
+{
+    if (!_readableData) 
+        _readableData = [[NSData dataWithData:_data] retain];
+    if (_data) {
+        [_data release];
+        _data = nil;
+    }
+}
+
+@end

--- a/Source/GPGPacket.h
+++ b/Source/GPGPacket.h
@@ -20,6 +20,8 @@
 #import <Cocoa/Cocoa.h>
 #import <Libmacgpg/GPGGlobals.h>
 
+@class GPGStream;
+
 @interface GPGPacket : NSObject {
 	GPGPacketType type;
 	NSData *data;
@@ -44,6 +46,8 @@
 
 + (id)packetsWithData:(NSData *)data;
 + (BOOL)isArmored:(const uint8_t)byte;
+// if return nil, input stream is not armored; should be reset and used directly
++ (NSData *)unArmorFrom:(GPGStream *)input clearText:(NSData **)clearText;
 + (NSData *)unArmor:(NSData *)data;
 + (NSData *)unArmor:(NSData *)theData clearText:(NSData **)clearText;
 + (NSData *)repairPacketData:(NSData *)data;

--- a/Source/GPGStream.h
+++ b/Source/GPGStream.h
@@ -1,0 +1,38 @@
+//
+//  GPGStream.h
+//  Libmacgpg
+//
+//  Created by Chris Fraire on 5/21/12.
+//  Copyright (c) 2012 Chris Fraire. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+// Abstract class for writing buffered data to a managed location
+@interface GPGStream : NSObject
+
+// append the specified data to the stream
+- (void)writeData:(NSData *)data;
+
+// read in to memory all the data from the current position to the end
+- (NSData *)readDataToEndOfStream;
+// read in to memory from the current position up to the specified length
+- (NSData *)readDataOfLength:(NSUInteger)length;
+// (re)read all data from the stream
+- (NSData *)readAllData;
+// return the character at the next position, without advancing position
+- (char)peekByte;
+
+// close the stream's underlying representation, when applicable
+- (void)close;
+// flush the underlying representation, when applicable
+- (void)flush;
+// seek the underlying representation back to the beginning; 
+// for a writeable stream, this truncates all data
+- (void)seekToBeginning;
+
+// readable streams may indicate total length; 
+// writeable streams may indicate length written;
+- (unsigned long long)length;
+
+@end

--- a/Source/GPGStream.m
+++ b/Source/GPGStream.m
@@ -1,0 +1,49 @@
+//
+//  GPGStream.m
+//  Libmacgpg
+//
+//  Created by Chris Fraire on 5/21/12.
+//  Copyright (c) 2012 Chris Fraire. All rights reserved.
+//
+
+#import "GPGStream.h"
+
+@implementation GPGStream
+
+- (void)writeData:(NSData *)data {
+    // nothing
+}
+
+- (NSData *)readDataToEndOfStream {
+    @throw [NSException exceptionWithName:@"NotImplementedException" reason:@"abstract method" userInfo:nil];
+}
+
+- (NSData *)readDataOfLength:(NSUInteger)length {
+    @throw [NSException exceptionWithName:@"NotImplementedException" reason:@"abstract method" userInfo:nil];
+}
+
+- (NSData *)readAllData {
+    @throw [NSException exceptionWithName:@"NotImplementedException" reason:@"abstract method" userInfo:nil];
+}
+
+- (char)peekByte {
+    @throw [NSException exceptionWithName:@"NotImplementedException" reason:@"abstract method" userInfo:nil];
+}
+
+- (void)close {
+    // nothing
+}
+
+- (void)flush {
+    // nothing
+}
+
+- (void)seekToBeginning {
+    @throw [NSException exceptionWithName:@"NotImplementedException" reason:@"abstract method" userInfo:nil];    
+}
+
+- (unsigned long long)length {
+    @throw [NSException exceptionWithName:@"NotImplementedException" reason:@"abstract method" userInfo:nil];
+}
+
+@end

--- a/Source/GPGTask.h
+++ b/Source/GPGTask.h
@@ -21,6 +21,7 @@
 #import "LPXTTask.h"
 
 @class GPGTask;
+@class GPGStream;
 
 @protocol GPGTaskDelegate
 @optional
@@ -51,7 +52,7 @@
     
 	NSMutableArray *inDatas;
 	
-	NSData *outData;
+    GPGStream *outStream;
 	NSData *errData;
 	NSData *statusData;
 	NSData *attributeData;
@@ -93,7 +94,8 @@
 @property (readonly) NSInteger exitcode;
 @property (readonly) int errorCode;
 @property (retain) NSString *gpgPath;
-@property (readonly, retain) NSData *outData;
+// if not set before starting, GPGTask will use a GPGMemoryStream
+@property (retain) GPGStream *outStream;
 @property (readonly, retain) NSData *errData;
 @property (readonly, retain) NSData *statusData;
 @property (readonly, retain) NSData *attributeData;
@@ -119,7 +121,8 @@
 
 - (void)cancel;
 
-
+- (NSData *)outData;
+- (void)addInput:(GPGStream *)stream;
 - (void)addInData:(NSData *)data;
 - (void)addInText:(NSString *)string;
 


### PR DESCRIPTION
Hi. I've updated GPGController with versions of processData, decryptData, and 
verifySignature to take a new stream object, GPGStream (with GPGMemoryStream 
and GPGFileStream concrete subclasses). The previous methods operate as 
before—though on top of implicit GPGStreams.

They do buffered reading of data to/from gpg2 using memory or the filesystem
and so will let GPGServices' file operations keep essentially the same memory 
footprint when operating on any size of file. (I have a version of GPGServices 
ready to go to use this). 

As you know, right now operating on files pulls their entire contents as well 
as the GPG output into memory even though it's just being saved to disk.

I looked into using NSStream and its subclasses, but that API is a bit stunted.
Libmacgpg's previous direct usage of NSData made it easier if the new stream 
objects supported seekability, peeking, and length determination, which 
NSInputStream does not.

also:
- fix minor memory leak with detached-signed files
- "Process data failed!" is now "Encrypt/sign failed!"

NOTE:
If GPGDebugLog is YES, the following will still read all of stdout into memory,
though the if-statement is new:

```
if ([GPGOptions debugLog]) 
    [self logDataContent:[self outData] message:@"[STDOUT]"];
```
