### PR TITLE
gpg-agent needs stronger convincing to use new pinentry-program

### DIFF
--- a/Source/GPGOptions.h
+++ b/Source/GPGOptions.h
@@ -98,6 +98,7 @@ typedef enum {
 
 
 - (void)gpgAgentFlush;
+- (void)gpgAgentTerminate;
 
 + (NSString *)standardizedKey:(NSString *)key;
 - (GPGOptionsDomain)domainForKey:(NSString *)key;

--- a/Source/GPGOptions.m
+++ b/Source/GPGOptions.m
@@ -447,6 +447,9 @@ uint8 debugLog;
 	system("killall -HUP gpg-agent");
 }
 
+- (void)gpgAgentTerminate {
+	system("killall gpg-agent");
+}
 
 
 // Notification handling.

--- a/Source/GPGTask.m
+++ b/Source/GPGTask.m
@@ -288,7 +288,7 @@ static NSString *GPG_STATUS_PREFIX = @"[GNUPG:] ";
         if ([possibleBins count] > 0) {
             inconfPath = [possibleBins objectAtIndex:0];
             [options setValue:inconfPath forKey:kPinentry_program inDomain:GPGDomain_gpgAgentConf];
-            [options gpgAgentFlush];
+            [options gpgAgentTerminate];
         }
     }
 


### PR DESCRIPTION
I had a hung gpg-agent when pinentry-program pointed to a defunct location,
and I was able to reproduce this.

This changes does a full killall in the case Libmacgpg writes a new value.

Do you guys think that's ok?
