### PR TITLE
GPGSignature desc shows fingerprint/algorithm when no userID available

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -76,6 +76,7 @@ GPG_EllipticCurveAlgorithm = "EllipticCurve";
 GPG_ECDSAAlgorithm = "ECDSA";
 GPG_ElgamalAlgorithm = "ELG";
 GPG_DiffieHellmanAlgorithm = "DiffieHellman";
+"Algorithm_%i" = "Algorithm_%i";
 
 /* GPGSignature humanReadableDescription */
 "Signed" = "Signed";

--- a/Source/GPGSignature.m
+++ b/Source/GPGSignature.m
@@ -20,6 +20,7 @@
 #import "GPGSignature.h"
 #import "GPGKey.h"
 #import "GPGGlobals.h"
+#import "GPGTransformer.h"
 
 @interface GPGSignature () <GPGUserIDProtocol>
 
@@ -199,8 +200,17 @@
     }
     
     NSMutableString *desc = [NSMutableString stringWithString:sigStatus];
-    if (self.userID && [self.userID length])
+    if (self.userID && [self.userID length]) {
         [desc appendFormat:@" (%@)", self.userID];
+    }
+    else if (self.fingerprint && [self.fingerprint length]) {
+        GPGKeyAlgorithmNameTransformer *algTransformer = [[GPGKeyAlgorithmNameTransformer alloc] init];
+        algTransformer.keepUnlocalized = !shouldLocalize;
+
+        NSString *algorithmDesc = [algTransformer transformedIntegerValue:self.publicKeyAlgorithm];
+        [desc appendFormat:@" (%@ %@)", self.fingerprint, algorithmDesc];
+        [algTransformer release];
+    }
     
     return desc;
 }

--- a/Source/GPGTransformer.h
+++ b/Source/GPGTransformer.h
@@ -20,11 +20,20 @@
 #import <Cocoa/Cocoa.h>
 
 
-@interface GPGKeyAlgorithmNameTransformer : NSValueTransformer {}
+@interface GPGKeyAlgorithmNameTransformer : NSValueTransformer {
+    BOOL _keepUnlocalized; // default NO; used for Unit Testing
+}
+// default NO
+@property (assign) BOOL keepUnlocalized;
+
 - (id)transformedIntegerValue:(NSInteger)value;
 @end
 
-@interface GPGKeyStatusDescriptionTransformer : NSValueTransformer {}
+@interface GPGKeyStatusDescriptionTransformer : NSValueTransformer {
+    BOOL _keepUnlocalized; // default NO; used for Unit Testing
+}
+// default NO
+@property (assign) BOOL keepUnlocalized;
 @end
 
 @interface SplitFormatter : NSFormatter {

--- a/Source/GPGTransformer.m
+++ b/Source/GPGTransformer.m
@@ -20,7 +20,12 @@
 #import "GPGTransformer.h"
 #import "GPGGlobals.h"
 
+#define maybeLocalize(key) (!_keepUnlocalized ? localizedLibmacgpgString(key) : key)
+
 @implementation GPGKeyAlgorithmNameTransformer
+
+@synthesize keepUnlocalized = _keepUnlocalized;
+
 + (Class)transformedValueClass { return [NSString class]; }
 + (BOOL)allowsReverseTransformation { return NO; }
 - (id)transformedValue:(id)value {
@@ -29,31 +34,34 @@
 - (id)transformedIntegerValue:(NSInteger)value {
 	switch (value) {
 		case GPG_RSAAlgorithm:
-			return localizedLibmacgpgString(@"GPG_RSAAlgorithm");
+			return maybeLocalize(@"GPG_RSAAlgorithm");
 		case GPG_RSAEncryptOnlyAlgorithm:
-			return localizedLibmacgpgString(@"GPG_RSAEncryptOnlyAlgorithm");
+			return maybeLocalize(@"GPG_RSAEncryptOnlyAlgorithm");
 		case GPG_RSASignOnlyAlgorithm:
-			return localizedLibmacgpgString(@"GPG_RSASignOnlyAlgorithm");
+			return maybeLocalize(@"GPG_RSASignOnlyAlgorithm");
 		case GPG_ElgamalEncryptOnlyAlgorithm:
-			return localizedLibmacgpgString(@"GPG_ElgamalEncryptOnlyAlgorithm");
+			return maybeLocalize(@"GPG_ElgamalEncryptOnlyAlgorithm");
 		case GPG_DSAAlgorithm:
-			return localizedLibmacgpgString(@"GPG_DSAAlgorithm");
+			return maybeLocalize(@"GPG_DSAAlgorithm");
 		case GPG_EllipticCurveAlgorithm:
-			return localizedLibmacgpgString(@"GPG_EllipticCurveAlgorithm");
+			return maybeLocalize(@"GPG_EllipticCurveAlgorithm");
 		case GPG_ECDSAAlgorithm:
-			return localizedLibmacgpgString(@"GPG_ECDSAAlgorithm");
+			return maybeLocalize(@"GPG_ECDSAAlgorithm");
 		case GPG_ElgamalAlgorithm:
-			return localizedLibmacgpgString(@"GPG_ElgamalAlgorithm");
+			return maybeLocalize(@"GPG_ElgamalAlgorithm");
 		case GPG_DiffieHellmanAlgorithm:
-			return localizedLibmacgpgString(@"GPG_DiffieHellmanAlgorithm");
+			return maybeLocalize(@"GPG_DiffieHellmanAlgorithm");
 		default:
-			return @"";
+			return [NSString stringWithFormat:maybeLocalize(@"Algorithm_%i"), value];
 	}
 }
 
 @end
 
 @implementation GPGKeyStatusDescriptionTransformer
+
+@synthesize keepUnlocalized = _keepUnlocalized;
+
 + (Class)transformedValueClass { return [NSString class]; }
 + (BOOL)allowsReverseTransformation { return NO; }
 - (id)transformedValue:(id)value {
@@ -62,33 +70,33 @@
 	
 	switch (intValue & 7) {
 		case 2:
-			[statusText appendString:localizedLibmacgpgString(@"?")]; //Was bedeutet 2? 
+			[statusText appendString:maybeLocalize(@"?")]; //Was bedeutet 2? 
 			break;
 		case 3:
-			[statusText appendString:localizedLibmacgpgString(@"Marginal")];
+			[statusText appendString:maybeLocalize(@"Marginal")];
 			break;
 		case 4:
-			[statusText appendString:localizedLibmacgpgString(@"Full")];
+			[statusText appendString:maybeLocalize(@"Full")];
 			break;
 		case 5:
-			[statusText appendString:localizedLibmacgpgString(@"Ultimate")];
+			[statusText appendString:maybeLocalize(@"Ultimate")];
 			break;
 		default:
-			[statusText appendString:localizedLibmacgpgString(@"Unknown")];
+			[statusText appendString:maybeLocalize(@"Unknown")];
 			break;
 	}
 	
 	if (intValue & GPGKeyStatus_Invalid) {
-		[statusText appendFormat:@", %@", localizedLibmacgpgString(@"Invalid")];
+		[statusText appendFormat:@", %@", maybeLocalize(@"Invalid")];
 	}
 	if (intValue & GPGKeyStatus_Revoked) {
-		[statusText appendFormat:@", %@", localizedLibmacgpgString(@"Revoked")];
+		[statusText appendFormat:@", %@", maybeLocalize(@"Revoked")];
 	}
 	if (intValue & GPGKeyStatus_Expired) {
-		[statusText appendFormat:@", %@", localizedLibmacgpgString(@"Expired")];
+		[statusText appendFormat:@", %@", maybeLocalize(@"Expired")];
 	}
 	if (intValue & GPGKeyStatus_Disabled) {
-		[statusText appendFormat:@", %@", localizedLibmacgpgString(@"Disabled")];
+		[statusText appendFormat:@", %@", maybeLocalize(@"Disabled")];
 	}
 	return [[statusText copy] autorelease];
 }

--- a/UnitTest/GPGSignatureTest.m
+++ b/UnitTest/GPGSignatureTest.m
@@ -51,19 +51,17 @@
 
 - (void)testNoPublicKeyDesc {
     GPGSignature *sig = [[GPGSignature alloc] init];
-    [sig addInfoFromStatusCode:GPG_STATUS_BADSIG andPrompt:@"ABCZYX someone@someplace.com"];
-    [sig addInfoFromStatusCode:GPG_STATUS_ERRSIG andPrompt:@"ABCZYX alg hash class date 9"];
+    [sig addInfoFromStatusCode:GPG_STATUS_ERRSIG andPrompt:@"ABCZYX 1 hash class date 9"];
     NSString *desc = [sig humanReadableDescriptionShouldLocalize:NO];
-    STAssertEqualObjects(desc, @"Signed by stranger (someone@someplace.com)", @"Unreadable!");
+    STAssertEqualObjects(desc, @"Signed by stranger (ABCZYX GPG_RSAAlgorithm)", @"Unreadable!");
     [sig release];
 }
 
 - (void)testUnknownAlgorithmDesc {
     GPGSignature *sig = [[GPGSignature alloc] init];
-    [sig addInfoFromStatusCode:GPG_STATUS_BADSIG andPrompt:@"ABCZYX someone@someplace.com"];
-    [sig addInfoFromStatusCode:GPG_STATUS_ERRSIG andPrompt:@"ABCZYX alg hash class date 4"];
+    [sig addInfoFromStatusCode:GPG_STATUS_ERRSIG andPrompt:@"ABCZYX 244 hash class date 4"];
     NSString *desc = [sig humanReadableDescriptionShouldLocalize:NO];
-    STAssertEqualObjects(desc, @"Unverifiable signature (someone@someplace.com)", @"Unreadable!");
+    STAssertEqualObjects(desc, @"Unverifiable signature (ABCZYX Algorithm_244)", @"Unreadable!");
     [sig release];
 }
 


### PR DESCRIPTION
Hi. This improves the signature humanReadableDescription.
- GPGKeyAlgorithmNameTransformer no longer returns "" for unknown
  algorithm, but instead "Algorithm_%i" with the code
- improves description for unknown public key and unknown algorithm
- proper setup for unit test to reflect a real unknown public key
  (only ERRSIG comes in)
- unit testing for GPGKeyAlgorithmNameTransformer
