### PR TITLE
Fix for @rpath used by XPCKit and a header not found error

### DIFF
--- a/Libmacgpg.xcodeproj/project.pbxproj
+++ b/Libmacgpg.xcodeproj/project.pbxproj
@@ -1070,7 +1070,7 @@
 				);
 				INFOPLIST_FILE = Resources/Info.plist;
 				INSTALL_PATH = "@loader_path/../Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks";
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = Libmacgpg;
 				RUN_CLANG_STATIC_ANALYZER = NO;
@@ -1095,7 +1095,7 @@
 				);
 				INFOPLIST_FILE = Resources/Info.plist;
 				INSTALL_PATH = "@loader_path/../Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks";
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = Libmacgpg;
 				WRAPPER_EXTENSION = framework;

--- a/Source/GPGTask.h
+++ b/Source/GPGTask.h
@@ -18,9 +18,9 @@
 */
 
 #import <Cocoa/Cocoa.h>
-#import "GPGTaskHelper.h"
 
 @class GPGTask;
+@class GPGTaskHelper;
 @class GPGStream;
 
 @protocol GPGTaskDelegate

--- a/Source/GPGTask.m
+++ b/Source/GPGTask.m
@@ -18,6 +18,7 @@
 */
 
 #import "GPGTask.h"
+#import "GPGTaskHelper.h"
 #import "GPGGlobals.h"
 #import "GPGOptions.h"
 #import "LPXTTask.h"


### PR DESCRIPTION
Hi, guys. Here's a couple of fixes for some build and run problems I was
having with the latest source.
- framework in a framework is at @rpath/Frameworks, not
  @rpath/../Frameworks as for an executable
- getting an odd build failure with GPGTask.h importing GPGTaskHelper.h
