### PR TITLE
Adaption to XCode 7.3.1

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+ 
+[libmacgpg.localizable]
+file_filter = Resources/<lang>.lproj/Localizable.strings
+source_lang = en
+source_file = Resources/en.lproj/Localizable.strings
+type = STRINGS

--- a/Resources/de.lproj/Localizable.strings
+++ b/Resources/de.lproj/Localizable.strings
@@ -5,7 +5,7 @@ PassphraseLabel = "Passphrase:";
 
 
 
-//Für den Schlüssel-Status
+//For Key-Status
 "Invalid" = "Ungültig";
 "Revoked" = "Widerrufen";
 "Expired" = "Abgelaufen";
@@ -16,7 +16,7 @@ PassphraseLabel = "Passphrase:";
 "Ultimate" = "Absolut";
 
 
-//Für Widerrufen und Wiederholen
+//For Undo and Redo
 Undo_NewKey = "Schlüssel erstellen";
 Undo_Delete = "Löschen";
 Undo_CleanKey = "Säubern";
@@ -76,3 +76,20 @@ GPG_EllipticCurveAlgorithm = "EllipticCurve";
 GPG_ECDSAAlgorithm = "ECDSA";
 GPG_ElgamalAlgorithm = "ELG";
 GPG_DiffieHellmanAlgorithm = "DiffieHellman";
+"Algorithm_%i" = "Algorithm_%i";
+
+/* GPGSignature humanReadableDescription */
+"Signed" = "Signed";
+"Signature expired" = "Signature expired";
+"Key expired" = "Key expired";
+"Bad signature" = "Bad signature";
+"Signature revoked" = "Signature revoked";
+"Signature error" = "Signature error";
+"Unverifiable signature" = "Unverifiable signature";
+"Signed by stranger" = "Signed by stranger";
+
+
+
+UpdaterNotWorking_Title = "The GPGSuite Updater doesn't work as expected!";
+UpdaterNotWorking_Msg = "Please download and re-install GPG Suite from https://gpgtools.org";
+

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -82,11 +82,11 @@ GPG_DiffieHellmanAlgorithm = "DiffieHellman";
 "Signed" = "Signed";
 "Signature expired" = "Signature expired";
 "Key expired" = "Key expired";
-"Bad signature" = "Bad signature";
+"Bad signature" = "Signature and data do not match. This could mean the data has been tampered with.";
 "Signature revoked" = "Signature revoked";
 "Signature error" = "Signature error";
-"Unverifiable signature" = "Unverifiable signature";
-"Signed by stranger" = "Signed by stranger";
+"Unverifiable signature" = "Signature can not be verified.";
+"Signed by stranger" = "Signature can not be verified, because the corresponding public key is missing.";
 
 
 

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 
-GetPassphraseDescription = "You need a passphrase to unlock the secret key for user: \"%@\", ID %@";
-GetPassphraseDescription_Subkey = "You need a passphrase to unlock the secret key for user: \"%@\", ID %@, (main key ID %@)";
-PassphraseLabel = "Passphrase:";
+GetPassphraseDescription = "You need a password to unlock the secret key for user: \"%@\", ID %@";
+GetPassphraseDescription_Subkey = "You need a password to unlock the secret key for user: \"%@\", ID %@, (main key ID %@)";
+PassphraseLabel = "Password:";
 
 
 
@@ -23,7 +23,7 @@ Undo_CleanKey = "Clean";
 Undo_MinimizeKey = "Minimize";
 Undo_RevokeKey = "Revoke Key";
 Undo_ChangeExpirationDate = "Change Expiration Date";
-Undo_ChangePassphrase = "Change Passphrase";
+Undo_ChangePassphrase = "Change Password";
 Undo_AlgorithmPreferences = "Change Algorithm Preferences";
 Undo_Import = "Import";
 Undo_AddSignature = "Add Signature";

--- a/Source/GPGStdSetting.m
+++ b/Source/GPGStdSetting.m
@@ -101,9 +101,18 @@
 
 - (NSString *) encodeValue {
     NSMutableString *result = [NSMutableString stringWithCapacity:0];
-
-    //value is NSNumber or NSString.
-    if ([value_ isKindOfClass:[NSNumber class]]) {
+	
+	//value_ is NSNumber, NSString or nil.
+	
+	BOOL isBool = NO;
+	if ([value_ isKindOfClass:[NSNumber class]]) {
+		char objCType = *[value_ objCType];
+		if (objCType == 'B' || objCType == 'c') {
+			isBool = YES;
+		}
+	}
+	
+	if (isBool) {
         if (!self.isActive)
             [result appendString:@"#"];
         


### PR DESCRIPTION
Because of the XCode 7.3.1 the main.c of installerHelper gets a compiler error. The reason is the direct access to the key structure and its mebers, which is not declared to be visible. Instead of this you have to use equivalent function to check the certificate type and get the RSA (see code below)

Starting at line 256 in main.c:

`  	// The public key is not RSA.
    int type = X509_certificate_type(certificate, pubkey);
	if((type & EVP_PK_RSA) != 0) {
		X509_free(certificate);
		free(plainData);
		free(signData);
		xar_close(pkg);
		return NO;
	}
	// RSA is not set.
    rsa = EVP_PKEY_get1_RSA(pubkey);
	if(!rsa) {
		X509_free(certificate);
		free(plainData);
		free(signData);
		xar_close(pkg);
		return NO;
	}

