### PR TITLE
very small error on the path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ If you're using GPGMail, follow these steps to install the xpc service helper.
 cp ./build/org.gpgtools.Libmacgpg.xpc.plist ~/Library/LaunchAgents/
 
 mkdir -p ~/Library/Application\ Support/GPGTools
-cp ~/build/Release/org.gpgtools.Libmacgpg.xpc ~/Library/Application\ Support/GPGTools
+cp ./build/Release/org.gpgtools.Libmacgpg.xpc ~/Library/Application\ Support/GPGTools
 
 launchctl unload ~/Library/LaunchAgents/org.gpgtools.Libmacgpg.xpc.plist
 launchctl load -w ~/Library/LaunchAgents/org.gpgtools.Libmacgpg.xpc.plist


### PR DESCRIPTION
Hi,
I've followed the README.md and installed the Lib, there should be replace ~ with . in the copy path.

Regards,
Wilson